### PR TITLE
Update requirement to python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or:
 ```
 conda install -c fastai fastprogress 
 ```
-Note that this requires python 3.6 or later.
+Note that this requires python 3.7 or later.
 
 ## Usage
 


### PR DESCRIPTION
Using python 3.6.x will result in an error as described in https://github.com/fastai/fastprogress/issues/20, suggest to update requirement to python 3.7 to avoid confusion.