### PR TITLE
Remove extra comma in progress bar HTML, causing rendering error when export to HTML

### DIFF
--- a/fastprogress/core.py
+++ b/fastprogress/core.py
@@ -28,7 +28,7 @@ def html_progress_bar(value, total, label, interrupted=False):
                 background: #F44336;
             }}
         </style>
-      <progress value='{value}' class='{bar_style}' max='{total}', style='width:300px; height:20px; vertical-align: middle;'></progress>
+      <progress value='{value}' class='{bar_style}' max='{total}' style='width:300px; height:20px; vertical-align: middle;'></progress>
       {label}
     </div>
     """

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -75,7 +75,7 @@
     "                background: #F44336;\n",
     "            }}\n",
     "        </style>\n",
-    "      <progress value='{value}' class='{bar_style}' max='{total}', style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+    "      <progress value='{value}' class='{bar_style}' max='{total}' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
     "      {label}\n",
     "    </div>\n",
     "    \"\"\""


### PR DESCRIPTION
Right now, fastprogress produces the erroneous HTML output that looks like this

```html
<progress value='2840' class='' max='2840', style='width:300px; height:20px; vertical-align: middle;'></progress>
```

This is an error b/c of an **extra comma between the properties `max` and `style`.**

I found this because it was surfaced in fastpages via https://github.com/fastai/fastpages/issues/191

This PR closes https://github.com/fastai/fastpages/issues/191