### PR TITLE
Fix issue 49

### DIFF
--- a/fastprogress/fastprogress.py
+++ b/fastprogress/fastprogress.py
@@ -22,7 +22,6 @@ class ProgressBar():
         else:
             self.leave,self.display=False,False
             parent.add_child(self)
-        self.last_v = None
 
     def on_iter_begin(self):
         if self.master is not None: self.master.on_iter_begin()

--- a/nbs/01_fastprogress.ipynb
+++ b/nbs/01_fastprogress.ipynb
@@ -47,7 +47,6 @@
     "        else:\n",
     "            self.leave,self.display=False,False\n",
     "            parent.add_child(self)\n",
-    "        self.last_v = None\n",
     "\n",
     "    def on_iter_begin(self):\n",
     "        if self.master is not None: self.master.on_iter_begin()\n",
@@ -806,12 +805,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Converted 00_core.ipynb.\n",
-      "Converted 01_fastprogress.ipynb.\n"
-     ]
+     "name": "stdout",
+     "text": "Converted 00_core.ipynb.\nConverted 01_fastprogress.ipynb.\n"
     }
    ],
    "source": [
@@ -833,9 +829,9 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6.9 64-bit ('fast': conda)",
    "language": "python",
-   "name": "python3"
+   "name": "python36964bitfastconda596c3be86cf94d3da06b9edc9ba11194"
   },
   "language_info": {
    "codemirror_mode": {
@@ -847,7 +843,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.9-final"
   },
   "toc": {
    "base_numbering": 1,

--- a/nbs/01_fastprogress.ipynb
+++ b/nbs/01_fastprogress.ipynb
@@ -47,7 +47,6 @@
     "        else:\n",
     "            self.leave,self.display=False,False\n",
     "            parent.add_child(self)\n",
-    "        self.last_v = None\n",
     "\n",
     "    def on_iter_begin(self):\n",
     "        if self.master is not None: self.master.on_iter_begin()\n",

--- a/nbs/01_fastprogress.ipynb
+++ b/nbs/01_fastprogress.ipynb
@@ -47,6 +47,7 @@
     "        else:\n",
     "            self.leave,self.display=False,False\n",
     "            parent.add_child(self)\n",
+    "        self.last_v = None\n",
     "\n",
     "    def on_iter_begin(self):\n",
     "        if self.master is not None: self.master.on_iter_begin()\n",
@@ -805,9 +806,12 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Converted 00_core.ipynb.\nConverted 01_fastprogress.ipynb.\n"
+     "output_type": "stream",
+     "text": [
+      "Converted 00_core.ipynb.\n",
+      "Converted 01_fastprogress.ipynb.\n"
+     ]
     }
    ],
    "source": [
@@ -829,9 +833,9 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3.6.9 64-bit ('fast': conda)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python36964bitfastconda596c3be86cf94d3da06b9edc9ba11194"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -843,7 +847,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9-final"
+   "version": "3.7.4"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The following error has been addressed in this patch

> File "/home/venv/lib/python3.7/site-packages/fastprogress/fastprogress.py", line 264, in add_child
>     self.child.prefix = f'Epoch {self.main_bar.last_v+1}/{self.main_bar.total} :'
> TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'

Looks like  `self.last_v` has been wrongly initialized to `None`.

Addressed the issue #49 