### PR TITLE
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'

### DIFF
--- a/fastprogress/fastprogress.py
+++ b/fastprogress/fastprogress.py
@@ -22,7 +22,7 @@ class ProgressBar():
         else:
             self.leave,self.display=False,False
             parent.add_child(self)
-        self.last_v = None
+        #self.last_v = None
 
     def on_iter_begin(self):
         if self.master is not None: self.master.on_iter_begin()


### PR DESCRIPTION
The below error happens in most of the course-v3/nbs/dl2 note books ( from 09c_add_progress_bar.ipynb to 12c_ulmfit.ipynb)
![image](https://user-images.githubusercontent.com/62723901/79013525-919e3c80-7b2e-11ea-9695-1a45176012a1.png)
So commented self.last_v = None in ProgressBar class,  __init__() function.
