### PR TITLE
Matching NB and Console MasterBar method signatures

### DIFF
--- a/fastprogress/fastprogress.py
+++ b/fastprogress/fastprogress.py
@@ -284,8 +284,8 @@ class ConsoleMasterBar(MasterBar):
             total_time = format_time(time() - self.start_t)
             print_and_maybe_save(f'Total time: {total_time}')
 
-    def show_imgs(*args): pass
-    def update_graph(*args): pass
+    def show_imgs(*args, **kwargs): pass
+    def update_graph(*args, **kwargs): pass
 
 # Cell
 if IN_NOTEBOOK: master_bar, progress_bar = NBMasterBar, NBProgressBar

--- a/nbs/01_fastprogress.ipynb
+++ b/nbs/01_fastprogress.ipynb
@@ -2,9 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/danielpcox/heap/fastprogress/nbs/fastprogress/fastprogress.py:102: UserWarning: Couldn't import ipywidgets properly, progress bar will use console behavior\n",
+      "  warn(\"Couldn't import ipywidgets properly, progress bar will use console behavior\")\n"
+     ]
+    }
+   ],
    "source": [
     "# export\n",
     "import time,os,shutil\n",
@@ -15,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -223,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,9 +250,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-12-66c7a8ece58d>:7: UserWarning: Couldn't import ipywidgets properly, progress bar will use console behavior\n",
+      "  warn(\"Couldn't import ipywidgets properly, progress bar will use console behavior\")\n"
+     ]
+    }
+   ],
    "source": [
     "#export\n",
     "if IN_NOTEBOOK:\n",
@@ -257,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,10 +305,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -329,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -489,10 +505,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -528,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,16 +611,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " |███████████████████████████████████████████████| 100.00% [100/100 00:05<00:00]\r"
+      "█\r"
      ]
     }
    ],
@@ -617,14 +629,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " |██████████████████████-------------------------| 47.00% [47/100 00:02<00:02]\r"
+      "█\r"
      ]
     }
    ],
@@ -638,7 +650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -652,7 +664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,24 +699,24 @@
     "            total_time = format_time(time() - self.start_t)\n",
     "            print_and_maybe_save(f'Total time: {total_time}')\n",
     "\n",
-    "    def show_imgs(*args): pass\n",
-    "    def update_graph(*args): pass"
+    "    def show_imgs(*args, **kwargs): pass\n",
+    "    def update_graph(*args, **kwargs): pass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Finished loop 0.                                                                         \n",
-      "Finished loop 1.                                                                         \n",
-      "Finished loop 2.                                                                         \n",
-      "Finished loop 3.                                                                         \n",
-      "Finished loop 4.                                                                         \n"
+      "Finished loop 0.\n",
+      "Finished loop 1.\n",
+      "Finished loop 2.\n",
+      "Finished loop 3.\n",
+      "Finished loop 4.\n"
      ]
     }
    ],
@@ -720,20 +732,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Finished loop 0.                                                                         \n",
-      "Finished loop 1.                                                                         \n",
-      "Finished loop 2.                                                                         \n",
-      "Finished loop 3.                                                                         \n",
-      "Finished loop 4.                                                                         \n"
+      "Finished loop 0.\n",
+      "Finished loop 1.\n",
+      "Finished loop 2.\n",
+      "Finished loop 3.\n",
+      "Finished loop 4.\n"
      ]
     }
    ],
@@ -746,12 +756,16 @@
     "        #mb.child.comment = f'second bar stat'\n",
     "    mb.main_bar.comment = f'first bar stat'\n",
     "    mb.write(f'Finished loop {i}.')\n",
-    "    mb.update(i+1)"
+    "    mb.update(i+1)\n",
+    "    \n",
+    "    # confirming a kwarg can be passed to ConsoleMasterBar instance\n",
+    "    mb.update_graph([[1,2],[3,4]], figsize=(10,5,))\n",
+    "    mb.show_imgs(figsize=(10,5,))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,7 +776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -772,7 +786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -784,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -803,7 +817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -829,39 +843,13 @@
   }
  ],
  "metadata": {
-  "hide_input": false,
   "jupytext": {
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "fastprogress",
    "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": true
+   "name": "fastprogress"
   }
  },
  "nbformat": 4,

--- a/nbs/01_fastprogress.ipynb
+++ b/nbs/01_fastprogress.ipynb
@@ -243,16 +243,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-12-66c7a8ece58d>:7: UserWarning: Couldn't import ipywidgets properly, progress bar will use console behavior\n",
-      "  warn(\"Couldn't import ipywidgets properly, progress bar will use console behavior\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#export\n",
     "if IN_NOTEBOOK:\n",

--- a/nbs/01_fastprogress.ipynb
+++ b/nbs/01_fastprogress.ipynb
@@ -4,16 +4,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/danielpcox/heap/fastprogress/nbs/fastprogress/fastprogress.py:102: UserWarning: Couldn't import ipywidgets properly, progress bar will use console behavior\n",
-      "  warn(\"Couldn't import ipywidgets properly, progress bar will use console behavior\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# export\n",
     "import time,os,shutil\n",


### PR DESCRIPTION
NBMasterBar had keyword args in two of its methods that were not handled in ConsoleMasterBar, which would cause projects using those kwargs to work correctly while in development in the notebook, but fail when run in the console, e.g., in projects using nbdev.

This PR just updates the two signatures for `update_graph` and `show_imgs` in ConsoleMasterBar to include `**kwargs`, and adds a couple of lines to the ConsoleMasterBar test to confirm.

Fixes #65 