### PR TITLE
Check that stdout exposes `isatty`

### DIFF
--- a/fastprogress/fastprogress.py
+++ b/fastprogress/fastprogress.py
@@ -208,7 +208,7 @@ MAX_COLS = 160
 
 # Cell
 def printing():
-    return False if NO_BAR else (stdout.isatty() or IN_NOTEBOOK)
+    return False if NO_BAR else (hasattr(stdout, 'isatty') and stdout.isatty() or IN_NOTEBOOK)
 
 # Cell
 class ConsoleProgressBar(ProgressBar):

--- a/nbs/01_fastprogress.ipynb
+++ b/nbs/01_fastprogress.ipynb
@@ -545,7 +545,7 @@
    "source": [
     "#export \n",
     "def printing():\n",
-    "    return False if NO_BAR else (stdout.isatty() or IN_NOTEBOOK)"
+    "    return False if NO_BAR else (hasattr(stdout, 'isatty') and stdout.isatty() or IN_NOTEBOOK)"
    ]
   },
   {


### PR DESCRIPTION
In embedded environments and other contexts, the `sys.stdout` stream may
be a custom implementation, and that implementation may not implement
`isatty`. Check for its existence before use. We ran into this in the case
of ArcGIS Pro which contains embedded Notebooks and uses fastprogress.