### PR TITLE
fix detection of PyCharm console as TTY

### DIFF
--- a/fastprogress/fastprogress.py
+++ b/fastprogress/fastprogress.py
@@ -211,7 +211,7 @@ MAX_COLS = 160
 
 # Cell
 def printing():
-    return False if NO_BAR else (stdout.isatty() or IN_NOTEBOOK)
+    return False if NO_BAR else (stdout.isatty() or IN_NOTEBOOK or 'PYCHARM_HOSTED' in os.environ)
 
 # Cell
 class ConsoleProgressBar(ProgressBar):


### PR DESCRIPTION
When running fastprogress in PyCharm (both as part of a script as well as in the interactive Python console), fastprogress does not output a progress bar:
![image](https://user-images.githubusercontent.com/5310424/120905808-eff07d80-c654-11eb-8b69-bb0955d620f6.png)
(same behavior as e.g. in #62)

This is because `sys.stdout.isatty()` returns `False` within PyCharm, and therefore the check in `printing` fails: https://github.com/fastai/fastprogress/blob/67d40725e0225de51c0dc43255fd78681c014eb8/fastprogress/fastprogress.py#L214

This PR adds an additional check for the `PYCHARM_HOSTED` environment variable to find out when fastprogress is run within PyCharm.

An alternative would be to set the "Emulate terminal in output console" option in PyCharm, however this only seems to apply to run configurations, not to the interactive Python console.